### PR TITLE
Add ceiling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ $ npm install node-cpu-count
 
 ## Usage
 
-#### `cpuCount(min = 1, max = os.cpus().length): Promise<number>`
+#### `cpuCount(min = 1, max = os.cpus().length, ceiling = true): Promise<number>`
 
 Get available logical CPU count (CPU quota / CPU period for cgroups, fallback to `os.cpus().length`).
 
-It always returns an integer by ceiling the result. The result can be used as the number of cluster workers.
+By default, it returns an integer by ceiling the result. The result can be used as the number of cluster workers.
 
 `min` or `max` can be specified to determine the minimal and the maximum CPU count (which also overrides the fallback value).
 
-#### `cpuCountSync(min = 1, max = os.cpus().length): number`
+#### `cpuCountSync(min = 1, max = os.cpus().length, ceiling = true): number`
 
 A synchronous version of `cpuCount`.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,20 +3,20 @@ import { normalizeQuota } from "./shared";
 import * as v1 from "./v1";
 import * as v2 from "./v2";
 
-export const cpuCount = async (min = 1, max = cpus().length) => {
+export const cpuCount = async (min = 1, max = cpus().length, ceiling = true) => {
   if (platform() !== "linux") return max;
   if (await v2.isV2()) {
-    return normalizeQuota(await v2.getCpuQuota(), min, max);
+    return normalizeQuota(await v2.getCpuQuota(), min, max, ceiling);
   } else {
-    return normalizeQuota(await v1.getCpuQuota(), min, max);
+    return normalizeQuota(await v1.getCpuQuota(), min, max, ceiling);
   }
 };
 
-export const cpuCountSync = (min = 1, max = cpus().length) => {
+export const cpuCountSync = (min = 1, max = cpus().length, ceiling = true) => {
   if (platform() !== "linux") return max;
   if (v2.isV2Sync()) {
-    return normalizeQuota(v2.getCpuQuotaSync(), min, max);
+    return normalizeQuota(v2.getCpuQuotaSync(), min, max, ceiling);
   } else {
-    return normalizeQuota(v1.getCpuQuotaSync(), min, max);
+    return normalizeQuota(v1.getCpuQuotaSync(), min, max, ceiling);
   }
 };

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,6 +1,6 @@
 import { cpus } from "os";
 
-export const normalizeQuota = (quota: number | undefined, min: number, max: number) => {
+export const normalizeQuota = (quota: number | undefined, min: number, max: number, ceiling: boolean = true) => {
   if (quota === undefined || !Number.isFinite(quota)) return max;
-  return Math.min(Math.max(min, Math.ceil(quota)), max);
+  return Math.min(Math.max(min, ceiling ? Math.ceil(quota) : quota), max);
 };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -53,7 +53,9 @@ describe("cgroups v2", () => {
 describe("shared", () => {
   test("normalizeQuota", () => {
     expect(normalizeQuota(1.1, 1, 8)).toStrictEqual(2);
+    expect(normalizeQuota(1.1, 1, 8, false)).toStrictEqual(1.1);
     expect(normalizeQuota(0.1, 2, 8)).toStrictEqual(2);
+    expect(normalizeQuota(0.1, 2, 8, false)).toStrictEqual(2);
     expect(normalizeQuota(-1, 2, 8)).toStrictEqual(2);
     expect(normalizeQuota(16, 2, 8)).toStrictEqual(8);
     expect(normalizeQuota(undefined, 1, 8)).toStrictEqual(8);


### PR DESCRIPTION
This PR adds a `ceiling` option, with default `true`; when `false` is passed, `Math.ceil(quota)` is skipped.

Resolves https://github.com/lujjjh/node-cpu-count/issues/1.